### PR TITLE
Remove pagination method limitation

### DIFF
--- a/src/Service/Request/Pagination/RequestPagination.php
+++ b/src/Service/Request/Pagination/RequestPagination.php
@@ -31,10 +31,6 @@ class RequestPagination implements RequestPaginationInterface
     {
         $this->request = $request;
 
-        if (strtoupper($request->getMethod()) !== 'GET') {
-            return;
-        }
-
         $limit = (int)$this->getParam($this->request, self::REQUEST_PARAM_LIMIT, self::DEFAULT_LIMIT);
 
         if ($limit > self::MAX_LIMIT) {


### PR DESCRIPTION
Pagination method was limited to "GET" only. We can't get page and limit number if using other request method. 