### PR TITLE
fix(QueryModifier): always add a unique alias in useQuery

### DIFF
--- a/src/Service/QueryModifier/UseQuery/UseQueryFromDotNotation.php
+++ b/src/Service/QueryModifier/UseQuery/UseQueryFromDotNotation.php
@@ -32,6 +32,8 @@ class UseQueryFromDotNotation
      */
     protected $query;
 
+    private static $counter = 0;
+
     /**
      * UseQueryFromDotNotation constructor.
      * @param ModelCriteria $query
@@ -132,7 +134,7 @@ class UseQueryFromDotNotation
                     $path = implode(self::RELATION_SEP, $this->map);
                     throw new RelationNotFoundException("Relation \"$relation\" Not Found in \"$path\"");
                 }
-                $alias = $alias ?? uniqid();
+                $alias = 'alias_' . self::$counter++;
                 $this->query = call_user_func([$this->query, $method], "`" . $alias . "_" . $relation . "`", $joinType);
             }
         }

--- a/src/Service/QueryModifier/UseQuery/UseQueryFromDotNotation.php
+++ b/src/Service/QueryModifier/UseQuery/UseQueryFromDotNotation.php
@@ -32,7 +32,7 @@ class UseQueryFromDotNotation
      */
     protected $query;
 
-    private static $counter = 0;
+    private static int $aliasesCnt = 0;
 
     /**
      * UseQueryFromDotNotation constructor.
@@ -134,7 +134,7 @@ class UseQueryFromDotNotation
                     $path = implode(self::RELATION_SEP, $this->map);
                     throw new RelationNotFoundException("Relation \"$relation\" Not Found in \"$path\"");
                 }
-                $alias = 'alias_' . self::$counter++;
+                $alias = 'alias_' . self::$aliasesCnt++;
                 $this->query = call_user_func([$this->query, $method], "`" . $alias . "_" . $relation . "`", $joinType);
             }
         }

--- a/src/Service/QueryModifier/UseQuery/UseQueryFromDotNotation.php
+++ b/src/Service/QueryModifier/UseQuery/UseQueryFromDotNotation.php
@@ -132,6 +132,7 @@ class UseQueryFromDotNotation
                     $path = implode(self::RELATION_SEP, $this->map);
                     throw new RelationNotFoundException("Relation \"$relation\" Not Found in \"$path\"");
                 }
+                $alias = $alias ?? uniqid();
                 $this->query = call_user_func([$this->query, $method], "`" . $alias . "_" . $relation . "`", $joinType);
             }
         }


### PR DESCRIPTION
Fix the Propel error "The given criteria contains an alias already existing in the current object", in case where a filter and a sort are used at the same time, on the same relation